### PR TITLE
Add support for multiarch builds

### DIFF
--- a/.github/actions/determine-target-image-tags/action
+++ b/.github/actions/determine-target-image-tags/action
@@ -3,6 +3,7 @@
 test -n "${GIT_REF}" || ( echo "GIT_REF is not specified" && false )
 test -n "${NGINX_TAG}" || ( echo "NGINX_TAG is not specified" && false )
 test -n "${MATRIX_NGINX}" || ( echo "MATRIX_NGINX is not specified" && false )
+test -n "${DOCKER_REPOSITORY}" || ( echo "DOCKER_REPOSITORY is not specified" && false )
 
 VERSION="$(echo ${GIT_REF} | grep -oE '[0-9]+\.[0-9]+\.[0-9]+.*' | tr -d '\n')"
 echo "VERSION=${VERSION}"
@@ -36,15 +37,15 @@ echo "LATEST_IMAGE_TAG=${LATEST_IMAGE_TAG}"
 
 # Push major version tag only if this is the latest version of that major version
 if [ "${VERSION}" = "${LATEST_VERSION_BY_MAJOR}" ]; then
-  TAGS="${MAJOR_IMAGE_TAG}"
+  TAGS="${DOCKER_REPOSITORY}:${MAJOR_IMAGE_TAG}"
 
   # Push latest tags only if this is the latest version of the latest major version
   if [ "${VERSION}" = "${GLOBAL_LATEST_VERSION}" ]; then
-    TAGS="${TAGS},${LATEST_IMAGE_TAG}"
+    TAGS="${TAGS},${DOCKER_REPOSITORY}:${LATEST_IMAGE_TAG}"
 
     # The "latest" tag should be based on nginx:stable-alpine
     if [ "${MATRIX_NGINX}" = "stable" ]; then
-      TAGS="${TAGS},latest"
+      TAGS="${TAGS},${DOCKER_REPOSITORY}:latest"
     fi
   fi
 fi
@@ -55,7 +56,7 @@ if [ "${MATRIX_NGINX}" = "{0}" ]; then
     TAGS="${TAGS},"
   fi
 
-  TAGS="${TAGS}${VERSION_IMAGE_TAG}"
+  TAGS="${TAGS}${DOCKER_REPOSITORY}:${VERSION_IMAGE_TAG}"
 fi
 
 echo "::set-output name=tags::${TAGS}"

--- a/.github/actions/determine-target-image-tags/action.yaml
+++ b/.github/actions/determine-target-image-tags/action.yaml
@@ -10,6 +10,9 @@ inputs:
   matrix-nginx:
     required: true
     description: 'Value of matrix.nginx'
+  docker-repository:
+    required: true
+    description: 'The docker-repository to prefix the tags with'
 outputs:
   tags:
     description: 'A comma separated list of tags to push'
@@ -20,3 +23,4 @@ runs:
     GIT_REF: "${{ inputs.git-ref }}"
     NGINX_TAG: "${{ inputs.nginx-tag }}"
     MATRIX_NGINX: "${{ inputs.matrix-nginx }}"
+    DOCKER_REPOSITORY: "${{ inputs.docker-repository }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,12 +39,23 @@ jobs:
           git-ref: "${{ github.ref }}"
           nginx-tag: "${{ steps.target_nginx_tag.outputs.tag }}"
           matrix-nginx: "${{ matrix.nginx }}"
-      - uses: docker/build-push-action@v1
+          docker-repository: "${{ secrets.DOCKER_REPOSITORY }}"
+      - uses: docker/setup-qemu-action@v2
+        name: Set up QEMU
+      - uses: docker/setup-buildx-action@v2
+        name: Set up Docker Buildx
+      - uses: docker/login-action@v2
+        name: Login to Docker Hub
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v4
+        name: Build and push
         if: ${{ steps.target_tags.outputs.tags != '' }}
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ secrets.DOCKER_REPOSITORY }}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          pull: true
           tags: ${{ steps.target_tags.outputs.tags }}
-          always_pull: true
-          build_args: NGINX_TAG=${{ steps.target_nginx_tag.outputs.tag }}
+          build-args: NGINX_TAG=${{ steps.target_nginx_tag.outputs.tag }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ steps.target_tags.outputs.tags != '' }}
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm/v7,linux/amd64,linux/arm64
           push: true
           pull: true
           tags: ${{ steps.target_tags.outputs.tags }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ steps.check_if_update_is_necessary.outputs.needs_update == 'true' && steps.target_image_name.outputs.tags != '' }}
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm/v7,linux/amd64,linux/arm64
           push: true
           pull: true
           tags: ${{ steps.target_image_name.outputs.tags }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -36,9 +36,9 @@ jobs:
           IMAGE_NAME="${{ secrets.DOCKER_REPOSITORY }}:${IMAGE_TAG}"
           echo "::set-output name=image_name::${IMAGE_NAME}"
           echo "IMAGE_NAME=${IMAGE_NAME}"
-          TAGS="${IMAGE_TAG}"
+          TAGS="${{ secrets.DOCKER_REPOSITORY }}:${IMAGE_TAG}"
           if [ "latest" = "${{ matrix.spa_server_major_version }}" ] && [ "stable" = "${{ matrix.nginx }}" ]; then
-            TAGS="${TAGS},latest"
+            TAGS="${TAGS},${{ secrets.DOCKER_REPOSITORY }}:latest"
           fi
           echo "::set-output name=tags::${TAGS}"
           echo "TAGS=${TAGS}"
@@ -70,12 +70,22 @@ jobs:
         if: steps.check_if_update_is_necessary.outputs.needs_update == 'true'
       - run: "make test NGINX_TAG=\"${{ steps.target_nginx_tag.outputs.tag }}\""
         if: steps.check_if_update_is_necessary.outputs.needs_update == 'true'
-      - uses: docker/build-push-action@v1
+      - uses: docker/setup-qemu-action@v2
+        name: Set up QEMU
+      - uses: docker/setup-buildx-action@v2
+        name: Set up Docker Buildx
+      - uses: docker/login-action@v2
+        name: Login to Docker Hub
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v4
+        name: Build and push
         if: ${{ steps.check_if_update_is_necessary.outputs.needs_update == 'true' && steps.target_image_name.outputs.tags != '' }}
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ secrets.DOCKER_REPOSITORY }}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          pull: true
           tags: ${{ steps.target_image_name.outputs.tags }}
-          always_pull: true
-          build_args: NGINX_TAG=${{ steps.target_nginx_tag.outputs.tag }}
+          build-args: NGINX_TAG=${{ steps.target_nginx_tag.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG NGINX_TAG
-FROM hairyhenderson/gomplate:v3-slim as gomplate
+FROM hairyhenderson/gomplate:v3 as gomplate
 FROM nginxinc/nginx-unprivileged:${NGINX_TAG} as single-page-app-server
 COPY --from=gomplate /gomplate /usr/local/bin/gomplate
 


### PR DESCRIPTION
Hello,

we are running a K8S cluster with mostly ARM nodes. It would be great if `single-page-application-server` could support arm.

I have not verified the images yet as I have a problem with getting GitHub actually pushing the images to docker hub:

```
#33 [auth] library/1-nginx-stable-alpine:pull,push token for registry-1.docker.io
#33 DONE 0.0s

#28 exporting to image
#28 pushing layers 0.4s done
#28 ERROR: failed to push 1-nginx-stable-alpine: server message: insufficient_scope: authorization failed
```

I currently don't understand where the `library` comes from, any idea?
